### PR TITLE
Add `sdmx`, `dsss`

### DIFF
--- a/catalogue.json
+++ b/catalogue.json
@@ -6,7 +6,7 @@
                 "supported_features" : "The SDMX Global Registry Content Policy published on sdmx.org sets out the policy for artefacts stored, maintained and disseminated from the SDMX Global Registry",
                 "url": "https://registry.sdmx.org/",
                 "image": "https://raw.githubusercontent.com/SDMX-Outreach/sdmx-tools-catalogue/main/images/tools/sdmx-global-registry.png"
-            },            
+            },
            {
                 "description": "The SDMX Test Compability Kit (SDMX TCK) is a tool for measuring the compliance and coverage of an SDMX RESTful endpoint against the available SDMX REST API versions",
                 "supported_features" : "<p>The objective of the SDMX TCK is to query an SDMX RESTful endpoint and provide a report with:</p><ul><li>The level of compliance, ie if the SDMX RESTful API is respected, by testing:<ul><li>All SDMX specified resources,</li><li>SDMX standard mime types,</li><li>The SDMX error codes,</li><li>Other features specified by the SDMX standard.</li></ul></li><li>The coverage: what percentage of resources and features are supported in terms of the specified responses.</li></ul>",
@@ -19,7 +19,7 @@
                 "url": "https://www.sdmx.io",
                 "image": "https://www.sdmx.io/images/icons/Kraken_Main.svg"
             }
-            
+
         ],
         "tools": [
             {
@@ -39,7 +39,7 @@
                 "license": "Apache",
                 "url": "https://www.sdmx.io/tools/fmr/",
                 "image": "https://www.sdmx.io/tools/fmr/FMR-Logo_FINAL_Icon.svg"
-            },       
+            },
             {
                 "name": "FMR Workbench",
                 "description": "The FMR Workbench is a remote registry browser and metadata maintenance tool which brings the strengths and capabilities of the FMR User Interface to any SDMX compliant registry, implementing an SDMX RESTful API",
@@ -48,7 +48,7 @@
                 "license": "Apache",
                 "url": "https://www.sdmx.io/tools/fwb/",
                 "image": "https://www.sdmx.io/images/tools/fwb-logo.jpg"
-            },      
+            },
             {
                 "name": "Fusion Transformer",
                 "description": "Fusion Transformer is a Java command line application that can be run on both Windows and Unix for transforming SDMX data and structure files supporting EDI, XML, JSON and CSV",
@@ -57,7 +57,7 @@
                 "license": "Apache",
                 "url": "https://www.sdmx.io/resources/download/ft/",
                 "image": "https://www.sdmx.io/images/products/card-ft.png"
-            },                              
+            },
             {
                 "name": "SDMX Dashboard Generator",
                 "description": "The SDMX Dashboard Generator (SDMX DG), co-winner of the SDMX Global Conference 2023 Hackathon, is an open source application that generates dynamic dashboards.",

--- a/catalogue.json
+++ b/catalogue.json
@@ -273,6 +273,24 @@
                 "license": "Commercial License",
                 "url": "https://www.meaningfuldata.eu",
                 "image": "https://raw.githubusercontent.com/SDMX-Outreach/sdmx-tools-catalogue/main/images/tools/sdmx_tools_default.svg"
+            },
+            {
+                "name": "sdmx1",
+                "description": "Python implementation of the SDMX Information Model, file formats, and SDMX-REST API client.",
+                "supported_features": "<ul><li>Complete, standards-compliant, Pythonic, and fully-documented implementation of the SDMX-IM 2.1 and 3.0.0 Information Models.</li><li>Input and output of SDMX-CSV, SDMX-ML, SDMX-JSON.</li><li>Conversion to pandas data structures.</li><li>Library of test specimens and full test coverage.</li></ul>",
+                "owner": "Paul Natsuo Kishimoto",
+                "license": "Apache 2.0",
+                "url": "https://sdmx1.readthedocs.io",
+                "image": "https://raw.githubusercontent.com/SDMX-Outreach/sdmx-tools-catalogue/main/images/tools/sdmx_tools_default.svg"
+            },
+            {
+                "name": "dsss",
+                "description": "A “dead-simple SDMX server” in Python.",
+                "supported_features": "<ul><li>Standards-compliant; returns SDMX-ML for all SDMX-REST API endpoints.</li><li>Configurable and extensible storage back-end for SDMX artefacts.</li><li><a href=\"https://www.starlette.io\">starlette</a>-based.</li></ul>",
+                "owner": "Paul Natsuo Kishimoto",
+                "license": "AGPL 3.0",
+                "url": "https://dsss.readthedocs.io",
+                "image": "https://raw.githubusercontent.com/SDMX-Outreach/sdmx-tools-catalogue/main/images/tools/sdmx_tools_default.svg"
             }
         ]
     }


### PR DESCRIPTION
Hi —adding these two tools per an e-mail invitation from Brian Buffett.

I have a few questions that weren't really answered in the README or by inspecting the current entries:

1. Should the entries be ordered in any way? e.g. alphabetically?
2. How are they ordered when displayed on the website?
3. Some entries use "AGPL-3.0 license" and others "AGPL-3.0". Does it matter which is used?
4. The text "AGPL-3.0" includes the license version number, whereas "Apache" does not, even though there are multiple versions of the Apache license. Should this be included?
5. Should domain-specific SDMX-based tools be included? I see there is a separate (mostly empty) [“Implementations”](https://sdmx.org/?page_id=81) page on the website. I also am involved in maintaining [transport-data/tools](https://github.com/transport-data/tools), which supports application of SDMX for transport data (item 2.4.4 on the implementation page). Can/should it be added to this repo/file?

Thanks!